### PR TITLE
fix(snapshot): fixed snapshots always created in testza directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ gen
 .DS_Store
 
 experimenting
+
+/.history

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TobiaszCudnik/testza
+module github.com/MarvinJWendt/testza
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MarvinJWendt/testza
+module github.com/TobiaszCudnik/testza
 
 go 1.15
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -22,7 +22,10 @@ import (
 //  testza.SnapshotCreate(t.Name(), objectToBeSnapshotted)
 func SnapshotCreate(name string, snapshotObject interface{}) error {
 	dir := getCurrentScriptDirectory() + "/testdata/snapshots/"
+	return snapshotCreateForDir(dir, name, snapshotObject)
+}
 
+func snapshotCreateForDir(dir string, name string, snapshotObject interface{}) error {
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return fmt.Errorf("creating snapshot failed: %w", err)
@@ -114,7 +117,7 @@ func SnapshotCreateOrValidate(t testRunner, name string, object interface{}, msg
 			return err
 		}
 	} else if os.IsNotExist(err) {
-		err = SnapshotCreate(name, object)
+		err = snapshotCreateForDir(dir, name, object)
 		if err != nil {
 			return err
 		}

--- a/snapshot.go
+++ b/snapshot.go
@@ -53,6 +53,12 @@ func snapshotCreateForDir(dir string, name string, snapshotObject interface{}) e
 //  testza.SnapshotValidate(t, t.Name(), objectToBeValidated, "Optional message")
 func SnapshotValidate(t testRunner, name string, actual interface{}, msg ...interface{}) error {
 	dir := getCurrentScriptDirectory() + "/testdata/snapshots/"
+	return snapshotValidateFromDir(dir, name, actual, msg...)
+}
+
+
+func snapshotValidateFromDir(dir string, t testRunner, name string, actual interface{}, msg ...interface{}) error {
+	dir := getCurrentScriptDirectory() + "/testdata/snapshots/"
 	snapshotPath := path.Clean(dir + name + ".testza")
 	snapshotContent, err := ioutil.ReadFile(snapshotPath)
 	snapshot := strings.ReplaceAll(string(snapshotContent), "\r\n", "\n")
@@ -112,7 +118,7 @@ func SnapshotCreateOrValidate(t testRunner, name string, object interface{}, msg
 	snapshotPath := path.Clean(dir + name + ".testza")
 
 	if _, err := os.Stat(snapshotPath); err == nil {
-		err = SnapshotValidate(t, name, object, msg...)
+		err = SnapshotValidateFromDir(dir, t, name, object, msg...)
 		if err != nil {
 			return err
 		}

--- a/snapshot.go
+++ b/snapshot.go
@@ -53,12 +53,10 @@ func snapshotCreateForDir(dir string, name string, snapshotObject interface{}) e
 //  testza.SnapshotValidate(t, t.Name(), objectToBeValidated, "Optional message")
 func SnapshotValidate(t testRunner, name string, actual interface{}, msg ...interface{}) error {
 	dir := getCurrentScriptDirectory() + "/testdata/snapshots/"
-	return snapshotValidateFromDir(dir, name, actual, msg...)
+	return snapshotValidateFromDir(dir, t, name, actual, msg...)
 }
 
-
 func snapshotValidateFromDir(dir string, t testRunner, name string, actual interface{}, msg ...interface{}) error {
-	dir := getCurrentScriptDirectory() + "/testdata/snapshots/"
 	snapshotPath := path.Clean(dir + name + ".testza")
 	snapshotContent, err := ioutil.ReadFile(snapshotPath)
 	snapshot := strings.ReplaceAll(string(snapshotContent), "\r\n", "\n")
@@ -118,7 +116,7 @@ func SnapshotCreateOrValidate(t testRunner, name string, object interface{}, msg
 	snapshotPath := path.Clean(dir + name + ".testza")
 
 	if _, err := os.Stat(snapshotPath); err == nil {
-		err = SnapshotValidateFromDir(dir, t, name, object, msg...)
+		err = snapshotValidateFromDir(dir, t, name, object, msg...)
 		if err != nil {
 			return err
 		}

--- a/utils.go
+++ b/utils.go
@@ -42,6 +42,6 @@ func generateMsg(msg []interface{}, addon ...interface{}) (out string) {
 }
 
 func getCurrentScriptDirectory() string {
-	_, scriptPath, _, _ := runtime.Caller(1)
+	_, scriptPath, _, _ := runtime.Caller(2)
 	return filepath.Join(scriptPath, "..")
 }


### PR DESCRIPTION
Snapshots work only within `testza` itself and when used in another module, try to create a fixture file within the `testza` dir (which results in no permission). 

This PR fixes a nesting issue in the snapshot support by extracting internal logic to a shared function (thus normalizing the stack trace).

Affected:
- `SnapshotCreateOrValidate`
- `SnapshotCreate`

PS. A regression test calling from another module would be nice, but not sure how to hook it up to the main `go test`.