### PR TITLE
fix: correct file perms on nested snapshot dir

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -128,7 +128,7 @@ func SnapshotCreateOrValidate(t testRunner, name string, object interface{}, msg
 	dir := getCurrentScriptDirectory() + "/testdata/snapshots/"
 	snapshotPath := path.Clean(dir + name + ".testza")
 	if strings.Contains(name, "/") {
-		err := os.MkdirAll(path.Dir(snapshotPath), 0600)
+		err := os.MkdirAll(path.Dir(snapshotPath), 0755)
 		if err != nil {
 			return fmt.Errorf("creating snapshot directories failed: %w", err)
 		}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -88,3 +88,24 @@ func TestSnapshotCreateOrValidate_invalid_name(t *testing.T) {
 	err := testza.SnapshotCreateOrValidate(t, string(rune(0))+"><", snapshotObject)
 	testza.AssertNotNil(t, err)
 }
+
+func TestSnapshotCreateOrValidate_nested_test_name(t *testing.T) {
+	snapshotNestedDirName := t.Name()
+	snapshotName := snapshotNestedDirName + "/nested_name"
+
+	snapshotFullPath := internal.GetCurrentScriptDirectory() + "/testdata/snapshots/" + snapshotNestedDirName
+
+	// ensure snapshot does not exist - remove snapshot and empty parent directory
+	if _, err := os.Stat(snapshotFullPath); err == nil {
+		_ = os.RemoveAll(snapshotFullPath)
+	}
+
+	err := testza.SnapshotCreateOrValidate(t, snapshotName, "snapshot-data")
+
+	// try to clean up before the assert so we leave the working copy clean
+	if _, err := os.Stat(snapshotFullPath); err == nil {
+		_ = os.RemoveAll(snapshotFullPath)
+	}
+
+	testza.AssertNoError(t, err)
+}


### PR DESCRIPTION
When the test name contains a path separator, make sure the directories are created with the correct permissions.

Fixes #107

Depends on #109 to fix the linting check failure.