### PR TITLE
ci: use fixed version of go for linting

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -6,8 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.39


### PR DESCRIPTION
The v3 action doesn't attempt to set up go, allowing the version already set to be used. This fixes an issue where the linter throws a pile of issues like:

```
  Error: undeclared name: `FuzzInputSdtringGenerateRandom` (typecheck)
  Error: undeclared name: `AssertEqual` (typecheck)
  Error: undeclared name: `AssertEqualValues` (typecheck)
  Error: undeclared name: `AssertKindOf` (typecheck)
  Error: undeclared name: `AssertTestFails` (typecheck)
```

An alternative is to set golangci-lint to target 1.18, but this disables a lot of checks.