### PR TITLE
Add getters for setters in configuration.go

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -105,6 +105,15 @@ func SetColorsEnabled(enabled bool) {
 	}
 }
 
+// GetColorsEnabled returns current value of ColorsEnabled setting.
+// ColorsEnabled controls if testza should print colored output.
+func GetColorsEnabled() bool {
+	initSync.Lock()
+	defer initSync.Unlock()
+
+	return pterm.PrintColor
+}
+
 // SetLineNumbersEnabled controls if line numbers should be printed in failing tests.
 // You should use this in the init() method of the package, which contains your tests.
 //
@@ -121,6 +130,15 @@ func SetLineNumbersEnabled(enabled bool) {
 	defer initSync.Unlock()
 
 	internal.LineNumbersEnabled = enabled
+}
+
+// GetLineNumbersEnabled returns current value of LineNumbersEnabled setting.
+// LineNumbersEnabled controls if line numbers should be printed in failing tests.
+func GetLineNumbersEnabled() bool {
+	initSync.Lock()
+	defer initSync.Unlock()
+
+	return internal.LineNumbersEnabled
 }
 
 // SetRandomSeed sets the seed for the random generator used in testza.
@@ -144,6 +162,14 @@ func SetRandomSeed(seed int64) {
 	rand.Seed(seed)
 }
 
+// GetRandomSeed returns current value of the random seed setting.
+func GetRandomSeed() int64 {
+	initSync.Lock()
+	defer initSync.Unlock()
+
+	return randomSeed
+}
+
 // SetShowStartupMessage controls if the startup message should be printed.
 // You should use this in the init() method of the package, which contains your tests.
 //
@@ -160,6 +186,15 @@ func SetShowStartupMessage(show bool) {
 	defer initSync.Unlock()
 
 	showStartupMessage = show
+}
+
+// GetShowStartupMessage returns current value of showStartupMessage setting.
+// showStartupMessage setting controls if the startup message should be printed.
+func GetShowStartupMessage() bool {
+	initSync.Lock()
+	defer initSync.Unlock()
+
+	return showStartupMessage
 }
 
 // SetDiffContextLines controls how many lines are shown around a changed diff line.
@@ -179,4 +214,14 @@ func SetDiffContextLines(lines int) {
 	defer initSync.Unlock()
 
 	internal.DiffContextLines = lines
+}
+
+// GetDiffContextLines returns current value of DiffContextLines setting.
+// DiffContextLines setting controls how many lines are shown around a changed diff line.
+// If set to -1 it will show full diff.
+func GetDiffContextLines() int {
+	initSync.Lock()
+	defer initSync.Unlock()
+
+	return internal.DiffContextLines
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -12,11 +12,13 @@ func TestSetColorsEnabled(t *testing.T) {
 	t.Run("Disable", func(t *testing.T) {
 		SetColorsEnabled(false)
 		AssertFalse(t, pterm.PrintColor)
+		AssertFalse(t, GetColorsEnabled())
 	})
 
 	t.Run("Enable", func(t *testing.T) {
 		SetColorsEnabled(true)
 		AssertTrue(t, pterm.PrintColor)
+		AssertTrue(t, GetColorsEnabled())
 	})
 }
 
@@ -24,53 +26,62 @@ func TestSetLineNumbersEnabled(t *testing.T) {
 	t.Run("Disable", func(t *testing.T) {
 		SetLineNumbersEnabled(false)
 		AssertFalse(t, internal.LineNumbersEnabled)
+		AssertFalse(t, GetLineNumbersEnabled())
 	})
 
 	t.Run("Enable", func(t *testing.T) {
 		SetLineNumbersEnabled(true)
 		AssertTrue(t, internal.LineNumbersEnabled)
+		AssertTrue(t, GetLineNumbersEnabled())
 	})
 }
 
 func TestSetRandomSeed(t *testing.T) {
 	SetRandomSeed(1337)
 	AssertEqual(t, int64(1337), randomSeed)
+	AssertEqual(t, int64(1337), GetRandomSeed())
 	AssertEqual(t, "4U390O49B9", FuzzStringGenerateRandom(1, 10)[0])
 	un := time.Now().UnixNano()
 	SetRandomSeed(un)
 	AssertEqual(t, un, randomSeed)
+	AssertEqual(t, un, GetRandomSeed())
 }
 
 func TestSetShowStartupMessage(t *testing.T) {
 	t.Run("Default is true", func(t *testing.T) {
 		AssertTrue(t, showStartupMessage)
-
+		AssertTrue(t, GetShowStartupMessage())
 	})
 
 	t.Run("Set to false", func(t *testing.T) {
 		SetShowStartupMessage(false)
 		AssertFalse(t, showStartupMessage)
+		AssertFalse(t, GetShowStartupMessage())
 	})
 
 	t.Run("Set to true", func(t *testing.T) {
 		SetShowStartupMessage(true)
 		AssertTrue(t, showStartupMessage)
+		AssertTrue(t, GetShowStartupMessage())
 	})
 }
 
 func TestSetEqualContextLineCount(t *testing.T) {
 	t.Run("Default is 2", func(t *testing.T) {
 		AssertEqual(t, 2, internal.DiffContextLines)
+		AssertEqual(t, 2, GetDiffContextLines())
 	})
 
 	t.Run("Set to -1", func(t *testing.T) {
 		SetDiffContextLines(-1)
 		AssertEqual(t, -1, internal.DiffContextLines)
+		AssertEqual(t, -1, GetDiffContextLines())
 	})
 
 	t.Run("Set to 3", func(t *testing.T) {
 		SetDiffContextLines(3)
 		AssertEqual(t, 3, internal.DiffContextLines)
+		AssertEqual(t, 3, GetDiffContextLines())
 	})
 
 	SetDiffContextLines(2)


### PR DESCRIPTION
Added getters for settings in `configuration.go`:
```go
func GetColorsEnabled() bool
func GetLineNumbersEnabled() bool
func GetRandomSeed() int64
func GetShowStartupMessage() bool
func GetDiffContextLines() int
```

closes #111