### PR TITLE
Show which test failed in `AssertTestFails`

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"time"
-	//"testing"
+	
 
 
 	"github.com/pterm/pterm"
@@ -712,7 +712,7 @@ func AssertTestFails(t testRunner, test func(t TestingPackageWithFailFunctions),
 		name := testing.Name()
 		testing.Logf("This test failed: %s", name)
 
-		
+	
 	}
 }
 

--- a/assert.go
+++ b/assert.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+	//"testing"
+
 
 	"github.com/pterm/pterm"
 
@@ -25,6 +27,7 @@ func (m *testMock) fail(msg ...any) {
 
 func (m *testMock) Error(args ...any) {
 	m.fail(args...)
+
 }
 
 // Errorf is a mock of testing.T.
@@ -50,6 +53,7 @@ func (m *testMock) Fatal(args ...any) {
 // Fatalf is a mock of testing.T.
 func (m *testMock) Fatalf(format string, args ...any) {
 	m.fail(fmt.Sprintf(format, args...))
+
 }
 
 // AssertKindOf asserts that the object is a type of kind exptectedKind.
@@ -700,9 +704,15 @@ func AssertTestFails(t testRunner, test func(t TestingPackageWithFailFunctions),
 
 	var mock testMock
 	test(&mock)
+	testing := internal.GetTest(t)
 
 	if !mock.ErrorCalled {
 		internal.Fail(t, "A test that !!should fail!! did not fail.", []internal.Object{}, msg...)
+		
+		name := testing.Name()
+		testing.Logf("This test failed: %s", name)
+
+		
 	}
 }
 


### PR DESCRIPTION
Hi, how are you?

This pull request addresses issue #147 about showing which test failed. I used the `t.Log()` function to indicate which test failed. But I don't know if it is better to replace the message "A test that should fail did not fail" or include the name of the test in that message or show two messages. Please let me know.

Have a nice day.